### PR TITLE
Emit missing scan metrics from ScanServer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/StatsIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/StatsIterator.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.iteratorsImpl.system;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -34,10 +35,10 @@ public class StatsIterator extends ServerWrappingIterator {
 
   private int numRead = 0;
   private AtomicLong seekCounter;
-  private AtomicLong readCounter;
+  private LongAdder readCounter;
 
   public StatsIterator(SortedKeyValueIterator<Key,Value> source, AtomicLong seekCounter,
-      AtomicLong readCounter) {
+      LongAdder readCounter) {
     super(source);
     this.seekCounter = seekCounter;
     this.readCounter = readCounter;
@@ -49,7 +50,7 @@ public class StatsIterator extends ServerWrappingIterator {
     numRead++;
 
     if (numRead % 23 == 0) {
-      readCounter.addAndGet(numRead);
+      readCounter.add(numRead);
       numRead = 0;
     }
   }
@@ -64,12 +65,12 @@ public class StatsIterator extends ServerWrappingIterator {
       throws IOException {
     source.seek(range, columnFamilies, inclusive);
     seekCounter.incrementAndGet();
-    readCounter.addAndGet(numRead);
+    readCounter.add(numRead);
     numRead = 0;
   }
 
   public void report() {
-    readCounter.addAndGet(numRead);
+    readCounter.add(numRead);
     numRead = 0;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetrics.java
@@ -66,8 +66,6 @@ public class TabletServerMetrics implements MetricsProducer {
         .description("Number of opening tablets").register(registry);
     Gauge.builder(METRICS_TSERVER_TABLETS_UNOPENED, util, TabletServerMetricsUtil::getUnopenedCount)
         .description("Number of unopened tablets").register(registry);
-    Gauge.builder(METRICS_TSERVER_QUERIES, util, TabletServerMetricsUtil::getLookupCount)
-        .description("Number of queries").register(registry);
     Gauge
         .builder(METRICS_TSERVER_MINC_TOTAL, util,
             TabletServerMetricsUtil::getTotalMinorCompactions)
@@ -83,13 +81,5 @@ public class TabletServerMetrics implements MetricsProducer {
         .description("Ingest rate (entries/sec)").register(registry);
     Gauge.builder(METRICS_TSERVER_INGEST_BYTES, util, TabletServerMetricsUtil::getIngestByteCount)
         .description("Ingest rate (bytes/sec)").register(registry);
-    Gauge.builder(METRICS_TSERVER_SCAN_RESULTS, util, TabletServerMetricsUtil::getQueryResultCount)
-        .description("Query rate (entries/sec)").register(registry);
-    Gauge
-        .builder(METRICS_TSERVER_SCAN_RESULTS_BYTES, util,
-            TabletServerMetricsUtil::getQueryByteCount)
-        .description("Query rate (bytes/sec)").register(registry);
-    Gauge.builder(METRICS_TSERVER_SCANNED_ENTRIES, util, TabletServerMetricsUtil::getScannedCount)
-        .description("Scanned rate").register(registry);
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
@@ -71,22 +71,6 @@ public class TabletServerMetricsUtil {
     return result;
   }
 
-  public double getQueryByteCount() {
-    double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets().values()) {
-      result += tablet.totalQueryResultsBytes();
-    }
-    return result;
-  }
-
-  public double getScannedCount() {
-    double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets().values()) {
-      result += tablet.totalScannedCount();
-    }
-    return result;
-  }
-
   public int getMajorCompactions() {
     var mgr = tserver.getCompactionManager();
     return mgr == null ? 0 : mgr.getCompactionsRunning();
@@ -121,22 +105,6 @@ public class TabletServerMetricsUtil {
 
   public int getOpeningCount() {
     return tserver.getOpeningCount();
-  }
-
-  public long getLookupCount() {
-    long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets().values()) {
-      result += tablet.totalLookupCount();
-    }
-    return result;
-  }
-
-  public long getQueryResultCount() {
-    long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets().values()) {
-      result += tablet.totalQueriesResults();
-    }
-    return result;
   }
 
   public int getUnopenedCount() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -176,8 +176,8 @@ class ScanDataSource implements DataSource {
         IteratorScope.scan, tablet.getTableConfiguration(), tablet.getExtent().tableId(),
         fileManager, files, scanParams.getAuthorizations(), samplerConfig, new ArrayList<>());
 
-    statsIterator =
-        new StatsIterator(multiIter, TabletServer.seekCount, tablet.getScannedCounter());
+    statsIterator = new StatsIterator(multiIter, TabletServer.seekCount, tablet.getScannedCounter(),
+        tablet.getScanMetrics().getScannedCounter());
 
     SortedKeyValueIterator<Key,Value> visFilter =
         SystemIteratorUtil.setupSystemScanIterators(statsIterator, scanParams.getColumnSet(),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1543,7 +1543,7 @@ public class Tablet extends TabletBase {
   }
 
   public long totalQueriesResults() {
-    return this.getScanMetrics().getQueryResultCount();
+    return this.queryResultCount.get();
   }
 
   public long totalIngest() {
@@ -1555,24 +1555,24 @@ public class Tablet extends TabletBase {
   }
 
   public long totalQueryResultsBytes() {
-    return this.getScanMetrics().getQueryByteCount();
+    return this.queryResultBytes.get();
   }
 
   public long totalScannedCount() {
-    return this.getScanMetrics().getScannedCount();
+    return this.scannedCount.get();
   }
 
   public long totalLookupCount() {
-    return this.getScanMetrics().getLookupCount();
+    return this.lookupCount.get();
   }
 
   // synchronized?
   public void updateRates(long now) {
-    queryRate.update(now, this.getScanMetrics().getQueryResultCount());
-    queryByteRate.update(now, this.getScanMetrics().getQueryByteCount());
+    queryRate.update(now, this.queryResultCount.get());
+    queryByteRate.update(now, this.queryResultBytes.get());
     ingestRate.update(now, ingestCount);
     ingestByteRate.update(now, ingestBytes);
-    scannedRate.update(now, this.getScanMetrics().getScannedCount());
+    scannedRate.update(now, this.scannedCount.get());
   }
 
   public long getSplitCreationTime() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -284,7 +284,7 @@ public class Tablet extends TabletBase {
       final TabletResourceManager trm, TabletData data)
       throws IOException, IllegalArgumentException {
 
-    super(tabletServer.getContext(), extent);
+    super(tabletServer, extent);
 
     this.tabletServer = tabletServer;
     this.tabletResources = trm;
@@ -1543,7 +1543,7 @@ public class Tablet extends TabletBase {
   }
 
   public long totalQueriesResults() {
-    return this.queryResultCount.get();
+    return this.getScanMetrics().getQueryResultCount();
   }
 
   public long totalIngest() {
@@ -1555,24 +1555,24 @@ public class Tablet extends TabletBase {
   }
 
   public long totalQueryResultsBytes() {
-    return this.queryResultBytes.get();
+    return this.getScanMetrics().getQueryByteCount();
   }
 
   public long totalScannedCount() {
-    return this.scannedCount.get();
+    return this.getScanMetrics().getScannedCount();
   }
 
   public long totalLookupCount() {
-    return this.lookupCount.get();
+    return this.getScanMetrics().getLookupCount();
   }
 
   // synchronized?
   public void updateRates(long now) {
-    queryRate.update(now, queryResultCount.get());
-    queryByteRate.update(now, queryResultBytes.get());
+    queryRate.update(now, this.getScanMetrics().getQueryResultCount());
+    queryByteRate.update(now, this.getScanMetrics().getQueryByteCount());
     ingestRate.update(now, ingestCount);
     ingestByteRate.update(now, ingestBytes);
-    scannedRate.update(now, scannedCount.get());
+    scannedRate.update(now, this.getScanMetrics().getScannedCount());
   }
 
   public long getSplitCreationTime() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
@@ -129,7 +129,8 @@ public class ScanServerTest {
     Map<String,String> execHints = new HashMap<>();
     TabletResolver resolver = createMock(TabletResolver.class);
 
-    expect(reservation.newTablet(sextent)).andReturn(tablet);
+    TestScanServer ss = partialMockBuilder(TestScanServer.class).createMock();
+    expect(reservation.newTablet(ss, sextent)).andReturn(tablet);
     reservation.close();
     reservation.close();
     expect(handler.startScan(tinfo, tcreds, sextent, trange, tcols, 10, titer, ssio, auths, false,
@@ -140,7 +141,6 @@ public class ScanServerTest {
 
     replay(reservation, handler);
 
-    TestScanServer ss = partialMockBuilder(TestScanServer.class).createMock();
     ss.delegate = handler;
     ss.extent = sextent;
     ss.resolver = resolver;
@@ -220,7 +220,8 @@ public class ScanServerTest {
       public void close() {}
     };
 
-    expect(reservation.newTablet(extent)).andReturn(tablet);
+    TestScanServer ss = partialMockBuilder(TestScanServer.class).createMock();
+    expect(reservation.newTablet(ss, extent)).andReturn(tablet);
     reservation.close();
     reservation.close();
     expect(handler.startMultiScan(tinfo, tcreds, tcols, titer, batch, ssio, auths, false, tsc, 30L,
@@ -230,7 +231,6 @@ public class ScanServerTest {
 
     replay(reservation, handler);
 
-    TestScanServer ss = partialMockBuilder(TestScanServer.class).createMock();
     ss.delegate = handler;
     ss.extent = extent;
     ss.resolver = resolver;


### PR DESCRIPTION
Moved lookupCount, scannedCount, queryResultCount, and queryBytesCount from
TabletServerMetricsUtil to TabletServerScanMetrics. Changed their type from
AtomicLong to LongAdder and fixed up the plumbing

Closes #2733