### PR TITLE
fix bugs found during scan server testing

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -199,7 +199,7 @@ function start_all() {
 
   for group in $SSERVER_GROUPS; do
     G="SSERVER_HOSTS_${group}"
-    for sserver in "${!G}"; do
+    for sserver in ${!G}; do
       start_service "$sserver" sserver "-g" "$group"
     done
   done
@@ -210,7 +210,7 @@ function start_all() {
 
   for queue in $COMPACTION_QUEUES; do
     Q="COMPACTOR_HOSTS_${queue}"
-    for compactor in "${!Q}"; do
+    for compactor in ${!Q}; do
       start_service "$compactor" compactor "-q" "$queue"
     done
   done
@@ -260,7 +260,7 @@ function start_here() {
   for group in $SSERVER_GROUPS; do
     for host in $local_hosts; do
       G="SSERVER_HOSTS_${group}"
-      for sserver in "${!G}"; do
+      for sserver in ${!G}; do
         if echo "$sserver" | grep -q "^${host}\$"; then
           start_service "$sserver" sserver "-g" "$group"
         fi
@@ -279,7 +279,7 @@ function start_here() {
   for queue in $COMPACTION_QUEUES; do
     for host in $local_hosts; do
       Q="COMPACTOR_HOSTS_${queue}"
-      for compactor in "${!Q}"; do
+      for compactor in ${!Q}; do
         if echo "$compactor" | grep -q "^${host}\$"; then
           start_service "$compactor" compactor "-q" "$queue"
         fi
@@ -336,7 +336,7 @@ function kill_all() {
 
   for group in $SSERVER_GROUPS; do
     G="SSERVER_HOSTS_${group}"
-    for sserver in "${!G}"; do
+    for sserver in ${!G}; do
       kill_service "$sserver" sserver "-g" "$group"
     done
   done
@@ -351,7 +351,7 @@ function kill_all() {
 
   for queue in $COMPACTION_QUEUES; do
     Q="COMPACTOR_HOSTS_${queue}"
-    for compactor in "${!Q}"; do
+    for compactor in ${!Q}; do
       kill_service "$compactor" compactor "-q" "$queue"
     done
   done
@@ -392,7 +392,7 @@ function stop_all() {
 
     for group in $SSERVER_GROUPS; do
       G="SSERVER_HOSTS_${group}"
-      for sserver in "${!G}"; do
+      for sserver in ${!G}; do
         end_service $end_cmd "$sserver" sserver "-g" "$group"
       done
     done
@@ -403,7 +403,7 @@ function stop_all() {
 
     for queue in $COMPACTION_QUEUES; do
       Q="COMPACTOR_HOSTS_${queue}"
-      for compactor in "${!Q}"; do
+      for compactor in ${!Q}; do
         end_service $end_cmd "$compactor" compactor "-q" "$queue"
       done
     done
@@ -440,13 +440,13 @@ function stop_here() {
       done
       for group in $SSERVER_GROUPS; do
         G="SSERVER_HOSTS_${group}"
-        for sserver in "${!G}"; do
+        for sserver in ${!G}; do
           end_service $end_cmd "$sserver" sserver "-g" "$group"
         done
       done
       for queue in $COMPACTION_QUEUES; do
         Q="COMPACTOR_HOSTS_${queue}"
-        for compactor in "${!Q}"; do
+        for compactor in ${!Q}; do
           end_service $end_cmd "$host" compactor "-q" "$queue"
         done
       done

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/DefaultScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/DefaultScanServerSelector.java
@@ -110,14 +110,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *       ]
  *     },
  *     {
- *       "scanTypeActivations":["slow"]
+ *       "scanTypeActivations":["slow"],
  *       "maxBusyTimeout":"20m",
  *       "busyTimeoutMultiplier":8,
- *       "group":"lowcost"
+ *       "group":"lowcost",
  *       "attemptPlans":[
  *         {"servers":"1", "busyTimeout":"10s"},
- *         {"servers":"3", "busyTimeout":"30s","salt","42"},
- *         {"servers":"9", "busyTimeout":"60s","salt","84"}
+ *         {"servers":"3", "busyTimeout":"30s","salt":"42"},
+ *         {"servers":"9", "busyTimeout":"60s","salt":"84"}
  *       ]
  *     }
  *    ]


### PR DESCRIPTION
With these changes I was able to run a successful test of scan server grouping on a cluster with 6 workers.  

Below are some notes from the testing I did.


```
hadoop@manager:/opt/accumulo-testing/accumulo/accumulo-2.1.0-SNAPSHOT$ tail conf/accumulo-client.properties 
## A list of span receiver classes to send trace spans
#trace.span.receivers=org.apache.accumulo.tracer.ZooTraceClient

## The zookeeper node where tracers are registered
#trace.zookeeper.path=/tracers

scan.server.selector.opts.profiles=[\
{"isDefault":true,"maxBusyTimeout":"5m","busyTimeoutMultiplier":4,"attemptPlans":[{"servers":"3", "busyTimeout":"33ms"},{"servers":"100%", "busyTimeout":"100ms"}]},\
{"scanTypeActivations":["slow"],maxBusyTimeout":"20m","busyTimeoutMultiplier":8,"group":"g2","attemptPlans":[{"servers":"1", "busyTimeout":"10s"},{"servers":"3", "busyTimeout":"30s","salt":"42"},{"servers":"9", "busyTimeout":"60s","salt":"84"}]}\
]
```

```
hadoop@manager:/opt/accumulo-testing/accumulo/accumulo-2.1.0-SNAPSHOT$ cat conf/cluster.yaml 
manager:
  - 10.0.2.10

monitor:
  - 10.0.2.10

gc:
  - 10.0.2.10

tserver:
  - 10.0.2.6
  - 10.0.2.5
  - 10.0.2.8
  - 10.0.2.4
  - 10.0.2.7
  - 10.0.2.9

sserver:
 - default:
    - 10.0.2.6
    - 10.0.2.5
    - 10.0.2.8
 - g2:
    - 10.0.2.4
    - 10.0.2.7
    - 10.0.2.9
```

```
hadoop@manager:/opt/accumulo-testing/accumulo/accumulo-2.1.0-SNAPSHOT$ accumulo shell -u root -p secret -e "scan -t t1 -cl eventual -np" 2>&1 | grep "Starting scan" | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}[:][0-9]+" | sort | uniq -c
      7 10.0.2.5:9996
      6 10.0.2.6:9996
      7 10.0.2.8:9996
```

```
hadoop@manager:/opt/accumulo-testing/accumulo/accumulo-2.1.0-SNAPSHOT$ accumulo shell -u root -p secret -e "scan -t t1 -cl eventual -np --execution-hints scan_type=slow" 2>&1 | grep "Starting scan" | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}[:][0-9]+" | sort | uniq -c
      7 10.0.2.4:9996
      6 10.0.2.7:9996
      7 10.0.2.9:9996
```

```
logger.aclient.name = org.apache.accumulo.core.clientImpl
logger.aclient.level = TRACE
```