### PR TITLE
Acquires tablet servers and their groups atomically

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -206,7 +206,8 @@ public class LiveTServerSet implements Watcher {
     }
   }
 
-  // The set of active tservers with locks, indexed by their name in zookeeper
+  // The set of active tservers with locks, indexed by their name in zookeeper. When the contents of
+  // this map are modified, tServersSnapshot should be set to null.
   private final Map<String,TServerInfo> current = new HashMap<>();
 
   private LiveTServersSnapshot tServersSnapshot = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/CurrentState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/CurrentState.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.server.manager.LiveTServerSet.LiveTServersSnapshot;
 
 public interface CurrentState {
 
@@ -32,7 +33,7 @@ public interface CurrentState {
 
   Set<TServerInstance> onlineTabletServers();
 
-  Map<String,Set<TServerInstance>> tServerResourceGroups();
+  LiveTServersSnapshot tserversSnapshot();
 
   Set<TServerInstance> shutdownServers();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -306,13 +306,13 @@ public class TabletManagementIterator extends SkippingIterator {
         new IteratorSetting(1001, "ManagerTabletInfoIterator", TabletManagementIterator.class);
     if (state != null) {
       LiveTServersSnapshot tserversSnapshot = state.tserversSnapshot();
-      TabletManagementIterator.setCurrentServers(tabletChange, tserversSnapshot.tservers);
+      TabletManagementIterator.setCurrentServers(tabletChange, tserversSnapshot.getTservers());
       TabletManagementIterator.setOnlineTables(tabletChange, state.onlineTables());
       TabletManagementIterator.setMigrations(tabletChange, state.migrationsSnapshot());
       TabletManagementIterator.setManagerState(tabletChange, state.getManagerState());
       TabletManagementIterator.setShuttingDown(tabletChange, state.shutdownServers());
       TabletManagementIterator.setTServerResourceGroups(tabletChange,
-          tserversSnapshot.tserverGroups);
+          tserversSnapshot.getTserverGroups());
       setCompactionHints(tabletChange, state.getCompactionHints());
     }
     scanner.addScanIterator(tabletChange);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -76,6 +76,7 @@ import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.server.compaction.CompactionJobGenerator;
 import org.apache.accumulo.server.iterators.TabletIteratorEnvironment;
+import org.apache.accumulo.server.manager.LiveTServerSet.LiveTServersSnapshot;
 import org.apache.accumulo.server.manager.balancer.BalancerEnvironmentImpl;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -304,13 +305,14 @@ public class TabletManagementIterator extends SkippingIterator {
     IteratorSetting tabletChange =
         new IteratorSetting(1001, "ManagerTabletInfoIterator", TabletManagementIterator.class);
     if (state != null) {
-      TabletManagementIterator.setCurrentServers(tabletChange, state.onlineTabletServers());
+      LiveTServersSnapshot tserversSnapshot = state.tserversSnapshot();
+      TabletManagementIterator.setCurrentServers(tabletChange, tserversSnapshot.tservers);
       TabletManagementIterator.setOnlineTables(tabletChange, state.onlineTables());
       TabletManagementIterator.setMigrations(tabletChange, state.migrationsSnapshot());
       TabletManagementIterator.setManagerState(tabletChange, state.getManagerState());
       TabletManagementIterator.setShuttingDown(tabletChange, state.shutdownServers());
       TabletManagementIterator.setTServerResourceGroups(tabletChange,
-          state.tServerResourceGroups());
+          tserversSnapshot.tserverGroups);
       setCompactionHints(tabletChange, state.getCompactionHints());
     }
     scanner.addScanIterator(tabletChange);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -129,6 +129,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.manager.LiveTServerSet;
+import org.apache.accumulo.server.manager.LiveTServerSet.LiveTServersSnapshot;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.manager.balancer.BalancerEnvironmentImpl;
 import org.apache.accumulo.server.manager.state.CurrentState;
@@ -819,12 +820,11 @@ public class Manager extends AbstractServer
     }
 
     private long updateStatus() {
-      Set<TServerInstance> currentServers = tserverSet.getCurrentServers();
+      var tseversSnapshot = tserverSet.getSnapshot();
       TreeMap<TabletServerId,TServerStatus> temp = new TreeMap<>();
-      tserverStatus = gatherTableInformation(currentServers, temp);
+      tserverStatus = gatherTableInformation(tseversSnapshot.tservers, temp);
       tserverStatusForBalancer = Collections.unmodifiableSortedMap(temp);
-      tServerGroupingForBalancer =
-          Collections.unmodifiableMap(tserverSet.getCurrentServersGroups());
+      tServerGroupingForBalancer = tseversSnapshot.tserverGroups;
       checkForHeldServer(tserverStatus);
 
       if (!badServers.isEmpty()) {
@@ -838,7 +838,7 @@ public class Manager extends AbstractServer
         log.debug("not balancing while shutting down servers {}", serversToShutdown);
       } else {
         for (TabletGroupWatcher tgw : watchers) {
-          if (!tgw.isSameTserversAsLastScan(currentServers)) {
+          if (!tgw.isSameTserversAsLastScan(tseversSnapshot.tservers)) {
             log.debug("not balancing just yet, as collection of live tservers is in flux");
             return DEFAULT_WAIT_FOR_WATCHER;
           }
@@ -1606,12 +1606,12 @@ public class Manager extends AbstractServer
 
   @Override
   public Set<TServerInstance> onlineTabletServers() {
-    return tserverSet.getCurrentServers();
+    return tserverSet.getSnapshot().tservers;
   }
 
   @Override
-  public Map<String,Set<TServerInstance>> tServerResourceGroups() {
-    return tserverSet.getCurrentServersGroups();
+  public LiveTServersSnapshot tserversSnapshot() {
+    return tserverSet.getSnapshot();
   }
 
   // recovers state from the persistent transaction to shutdown a server

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -822,9 +822,9 @@ public class Manager extends AbstractServer
     private long updateStatus() {
       var tseversSnapshot = tserverSet.getSnapshot();
       TreeMap<TabletServerId,TServerStatus> temp = new TreeMap<>();
-      tserverStatus = gatherTableInformation(tseversSnapshot.tservers, temp);
+      tserverStatus = gatherTableInformation(tseversSnapshot.getTservers(), temp);
       tserverStatusForBalancer = Collections.unmodifiableSortedMap(temp);
-      tServerGroupingForBalancer = tseversSnapshot.tserverGroups;
+      tServerGroupingForBalancer = tseversSnapshot.getTserverGroups();
       checkForHeldServer(tserverStatus);
 
       if (!badServers.isEmpty()) {
@@ -838,7 +838,7 @@ public class Manager extends AbstractServer
         log.debug("not balancing while shutting down servers {}", serversToShutdown);
       } else {
         for (TabletGroupWatcher tgw : watchers) {
-          if (!tgw.isSameTserversAsLastScan(tseversSnapshot.tservers)) {
+          if (!tgw.isSameTserversAsLastScan(tseversSnapshot.getTservers())) {
             log.debug("not balancing just yet, as collection of live tservers is in flux");
             return DEFAULT_WAIT_FOR_WATCHER;
           }
@@ -1606,7 +1606,7 @@ public class Manager extends AbstractServer
 
   @Override
   public Set<TServerInstance> onlineTabletServers() {
-    return tserverSet.getSnapshot().tservers;
+    return tserverSet.getSnapshot().getTservers();
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,7 @@ import org.apache.accumulo.server.compaction.CompactionJobGenerator;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.accumulo.server.log.WalStateManager.WalMarkerException;
+import org.apache.accumulo.server.manager.LiveTServerSet;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.manager.state.Assignment;
 import org.apache.accumulo.server.manager.state.ClosableIterator;
@@ -173,10 +175,30 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
     public TabletLists(Manager m, SortedMap<TServerInstance,TabletServerStatus> curTServers,
         Map<String,Set<TServerInstance>> grouping) {
-      var destinationsMod = new TreeMap<>(curTServers);
-      destinationsMod.keySet().removeAll(m.serversToShutdown);
-      this.destinations = Collections.unmodifiableSortedMap(destinationsMod);
-      this.currentTServerGrouping = grouping;
+      synchronized (m.serversToShutdown) {
+        var destinationsMod = new TreeMap<>(curTServers);
+        if (!m.serversToShutdown.isEmpty()) {
+          // Remove servers that are in the process of shutting down from the lists of tablet
+          // servers.
+          destinationsMod.keySet().removeAll(m.serversToShutdown);
+          HashMap<String,Set<TServerInstance>> groupingCopy = new HashMap<>();
+          grouping.forEach((group, groupsServers) -> {
+            if (Collections.disjoint(groupsServers, m.serversToShutdown)) {
+              groupingCopy.put(group, groupsServers);
+            } else {
+              var serversCopy = new HashSet<>(groupsServers);
+              serversCopy.removeAll(m.serversToShutdown);
+              groupingCopy.put(group, Collections.unmodifiableSet(serversCopy));
+            }
+          });
+
+          this.currentTServerGrouping = Collections.unmodifiableMap(groupingCopy);
+        } else {
+          this.currentTServerGrouping = grouping;
+        }
+
+        this.destinations = Collections.unmodifiableSortedMap(destinationsMod);
+      }
     }
 
     public void reset() {
@@ -218,15 +240,17 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
               continue;
             }
 
-            var currentTservers = getCurrentTservers();
-            if (currentTservers.isEmpty()) {
+            LiveTServerSet.LiveTServersSnapshot tservers = manager.tserverSet.getSnapshot();
+            var tserversStatus = getTserversStatus(tservers.tservers);
+
+            if (tserversStatus.isEmpty()) {
               setNeedsFullScan();
               continue;
             }
 
             try (var iter = store.iterator(ranges)) {
               long t1 = System.currentTimeMillis();
-              manageTablets(iter, currentTservers, false);
+              manageTablets(iter, tserversStatus, tservers.tserverGroups, false);
               long t2 = System.currentTimeMillis();
               Manager.log.debug(String.format("[%s]: partial scan time %.2f seconds for %,d ranges",
                   store.name(), (t2 - t1) / 1000., ranges.size()));
@@ -296,13 +320,14 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
   }
 
   private TableMgmtStats manageTablets(Iterator<TabletManagement> iter,
-      SortedMap<TServerInstance,TabletServerStatus> currentTServers, boolean isFullScan)
+      SortedMap<TServerInstance,TabletServerStatus> tseversStatus,
+      Map<String,Set<TServerInstance>> tserverGroups, boolean isFullScan)
       throws BadLocationStateException, TException, DistributedStoreException, WalMarkerException,
       IOException {
 
     TableMgmtStats tableMgmtStats = new TableMgmtStats();
     final boolean shuttingDownAllTabletServers =
-        manager.serversToShutdown.equals(currentTServers.keySet());
+        manager.serversToShutdown.equals(tseversStatus.keySet());
     if (shuttingDownAllTabletServers && !isFullScan) {
       // If we are shutting down all of the TabletServers, then don't process any events
       // from the EventCoordinator.
@@ -312,16 +337,13 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
     int unloaded = 0;
 
-    final Map<String,Set<TServerInstance>> currentTServerGrouping =
-        manager.tserverSet.getCurrentServersGroups();
-
-    TabletLists tLists = new TabletLists(manager, currentTServers, currentTServerGrouping);
+    TabletLists tLists = new TabletLists(manager, tseversStatus, tserverGroups);
 
     CompactionJobGenerator compactionGenerator = new CompactionJobGenerator(
         new ServiceEnvironmentImpl(manager.getContext()), manager.getCompactionHints());
 
     final Map<TabletServerId,String> resourceGroups = new HashMap<>();
-    manager.tServerResourceGroups().forEach((group, tservers) -> {
+    tserverGroups.forEach((group, tservers) -> {
       tservers.stream().map(TabletServerIdImpl::new)
           .forEach(tabletServerId -> resourceGroups.put(tabletServerId, group));
     });
@@ -360,7 +382,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       // Don't overwhelm the tablet servers with work
       if (tLists.unassigned.size() + unloaded
-          > Manager.MAX_TSERVER_WORK_CHUNK * currentTServers.size()) {
+          > Manager.MAX_TSERVER_WORK_CHUNK * tseversStatus.size()) {
         flushChanges(tLists);
         tLists.reset();
         unloaded = 0;
@@ -370,7 +392,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       TabletGoalState goal = manager.getGoalState(tm);
       TabletState state =
-          TabletState.compute(tm, currentTServers.keySet(), manager.tabletBalancer, resourceGroups);
+          TabletState.compute(tm, tseversStatus.keySet(), manager.tabletBalancer, resourceGroups);
 
       final Location location = tm.getLocation();
       Location current = null;
@@ -402,7 +424,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       if (Manager.log.isTraceEnabled()) {
         Manager.log.trace(
             "[{}] Shutting down all Tservers: {}, dependentCount: {} Extent: {}, state: {}, goal: {} actions:{}",
-            store.name(), manager.serversToShutdown.equals(currentTServers.keySet()),
+            store.name(), manager.serversToShutdown.equals(tseversStatus.keySet()),
             dependentWatcher == null ? "null" : dependentWatcher.assignedOrHosted(), tm.getExtent(),
             state, goal, actions);
       }
@@ -541,10 +563,11 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     return tableMgmtStats;
   }
 
-  private SortedMap<TServerInstance,TabletServerStatus> getCurrentTservers() {
+  private SortedMap<TServerInstance,TabletServerStatus>
+      getTserversStatus(Set<TServerInstance> currentServers) {
     // Get the current status for the current list of tservers
     final SortedMap<TServerInstance,TabletServerStatus> currentTServers = new TreeMap<>();
-    for (TServerInstance entry : manager.tserverSet.getCurrentServers()) {
+    for (TServerInstance entry : currentServers) {
       currentTServers.put(entry, manager.tserverStatus.get(entry));
     }
     return currentTServers;
@@ -563,11 +586,12 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       final long waitTimeBetweenScans = manager.getConfiguration()
           .getTimeInMillis(Property.MANAGER_TABLET_GROUP_WATCHER_INTERVAL);
 
-      var currentTServers = getCurrentTservers();
+      LiveTServerSet.LiveTServersSnapshot tservers = manager.tserverSet.getSnapshot();
+      var tserversStatus = getTserversStatus(tservers.tservers);
 
       ClosableIterator<TabletManagement> iter = null;
       try {
-        if (currentTServers.isEmpty()) {
+        if (tserversStatus.isEmpty()) {
           eventHandler.waitForFullScan(waitTimeBetweenScans);
           synchronized (this) {
             lastScanServers = Collections.emptySortedSet();
@@ -584,7 +608,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         eventHandler.clearNeedsFullScan();
 
         iter = store.iterator();
-        var tabletMgmtStats = manageTablets(iter, currentTServers, true);
+        var tabletMgmtStats = manageTablets(iter, tserversStatus, tservers.tserverGroups, true);
 
         // provide stats after flushing changes to avoid race conditions w/ delete table
         stats.end(managerState);
@@ -607,9 +631,9 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         }
 
         synchronized (this) {
-          lastScanServers = ImmutableSortedSet.copyOf(currentTServers.keySet());
+          lastScanServers = ImmutableSortedSet.copyOf(tserversStatus.keySet());
         }
-        if (manager.tserverSet.getCurrentServers().equals(currentTServers.keySet())) {
+        if (manager.tserverSet.getCurrentServers().equals(tserversStatus.keySet())) {
           Manager.log.debug(String.format("[%s] sleeping for %.2f seconds", store.name(),
               waitTimeBetweenScans / 1000.));
           eventHandler.waitForFullScan(waitTimeBetweenScans);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -241,7 +241,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
             }
 
             LiveTServerSet.LiveTServersSnapshot tservers = manager.tserverSet.getSnapshot();
-            var tserversStatus = getTserversStatus(tservers.tservers);
+            var tserversStatus = getTserversStatus(tservers.getTservers());
 
             if (tserversStatus.isEmpty()) {
               setNeedsFullScan();
@@ -250,7 +250,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
             try (var iter = store.iterator(ranges)) {
               long t1 = System.currentTimeMillis();
-              manageTablets(iter, tserversStatus, tservers.tserverGroups, false);
+              manageTablets(iter, tserversStatus, tservers.getTserverGroups(), false);
               long t2 = System.currentTimeMillis();
               Manager.log.debug(String.format("[%s]: partial scan time %.2f seconds for %,d ranges",
                   store.name(), (t2 - t1) / 1000., ranges.size()));
@@ -587,7 +587,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
           .getTimeInMillis(Property.MANAGER_TABLET_GROUP_WATCHER_INTERVAL);
 
       LiveTServerSet.LiveTServersSnapshot tservers = manager.tserverSet.getSnapshot();
-      var tserversStatus = getTserversStatus(tservers.tservers);
+      var tserversStatus = getTserversStatus(tservers.getTservers());
 
       ClosableIterator<TabletManagement> iter = null;
       try {
@@ -608,7 +608,8 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         eventHandler.clearNeedsFullScan();
 
         iter = store.iterator();
-        var tabletMgmtStats = manageTablets(iter, tserversStatus, tservers.tserverGroups, true);
+        var tabletMgmtStats =
+            manageTablets(iter, tserversStatus, tservers.getTserverGroups(), true);
 
         // provide stats after flushing changes to avoid race conditions w/ delete table
         stats.end(managerState);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -587,11 +587,11 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
           .getTimeInMillis(Property.MANAGER_TABLET_GROUP_WATCHER_INTERVAL);
 
       LiveTServerSet.LiveTServersSnapshot tservers = manager.tserverSet.getSnapshot();
-      var tserversStatus = getTserversStatus(tservers.getTservers());
+      var currentTServers = getTserversStatus(tservers.getTservers());
 
       ClosableIterator<TabletManagement> iter = null;
       try {
-        if (tserversStatus.isEmpty()) {
+        if (currentTServers.isEmpty()) {
           eventHandler.waitForFullScan(waitTimeBetweenScans);
           synchronized (this) {
             lastScanServers = Collections.emptySortedSet();
@@ -609,7 +609,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
         iter = store.iterator();
         var tabletMgmtStats =
-            manageTablets(iter, tserversStatus, tservers.getTserverGroups(), true);
+            manageTablets(iter, currentTServers, tservers.getTserverGroups(), true);
 
         // provide stats after flushing changes to avoid race conditions w/ delete table
         stats.end(managerState);
@@ -632,9 +632,9 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         }
 
         synchronized (this) {
-          lastScanServers = ImmutableSortedSet.copyOf(tserversStatus.keySet());
+          lastScanServers = ImmutableSortedSet.copyOf(currentTServers.keySet());
         }
-        if (manager.tserverSet.getCurrentServers().equals(tserversStatus.keySet())) {
+        if (manager.tserverSet.getCurrentServers().equals(currentTServers.keySet())) {
           Manager.log.debug(String.format("[%s] sleeping for %.2f seconds", store.name(),
               waitTimeBetweenScans / 1000.));
           eventHandler.waitForFullScan(waitTimeBetweenScans);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
@@ -71,6 +71,7 @@ import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.server.manager.LiveTServerSet;
 import org.apache.accumulo.server.manager.state.CurrentState;
 import org.apache.accumulo.server.manager.state.TabletManagementIterator;
 import org.apache.hadoop.io.Text;
@@ -373,16 +374,16 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
     }
 
     @Override
+    public LiveTServerSet.LiveTServersSnapshot tserversSnapshot() {
+      return new LiveTServerSet.LiveTServersSnapshot(onlineTabletServers(), new HashMap<>());
+    }
+
+    @Override
     public Set<TableId> onlineTables() {
       Set<TableId> onlineTables = context.getTableIdToNameMap().keySet();
       this.onlineTables =
           Sets.filter(onlineTables, tableId -> context.getTableState(tableId) == TableState.ONLINE);
       return this.onlineTables;
-    }
-
-    @Override
-    public Map<String,Set<TServerInstance>> tServerResourceGroups() {
-      return new HashMap<>();
     }
 
     @Override


### PR DESCRIPTION
Fixes two bugs that could cause the set of tservers and map of group tservers to have an inconsistent set of tservers.

Modified LiveTserverSet so that the set of tablet servers and the tablet servers resource groups can be acquired atomically.  The code was acquiring this information at two different times with two different lock acquisitions, which could have led to race condtions resulting differences in set and the map.

Also modified TGW.TabletLists to filter out shutting down servers from the grouped tservers in addition to filtering from the tserver set.