### PR TITLE
multiple updates to volume replacement

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -934,6 +934,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     control.stop(ServerType.MANAGER, null);
     control.stop(ServerType.TABLET_SERVER, null);
     control.stop(ServerType.ZOOKEEPER, null);
+    control.stop(ServerType.COMPACTOR, null);
+    control.stop(ServerType.SCAN_SERVER, null);
 
     // ACCUMULO-2985 stop the ExecutorService after we finished using it to stop accumulo procs
     if (executor != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.spi.balancer.TabletBalancer;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.tablet.thrift.TUnloadTabletGoal;
+import org.apache.accumulo.server.fs.VolumeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,6 +144,10 @@ public enum TabletGoalState {
               "Could not find resource group for tserver {}, so did not consult balancer.  Need to determine the cause of this.",
               tm.getLocation().getServerInstance());
         }
+      }
+
+      if (VolumeUtil.needsVolumeReplacement(params.getVolumeReplacements(), tm)) {
+        return UNASSIGNED;
       }
 
       if (tm.hasCurrent()

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.compaction.CompactionJobGenerator;
+import org.apache.accumulo.server.fs.VolumeUtil;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +94,11 @@ class ZooTabletStateStore extends AbstractTabletStateStore implements TabletStat
           log.error("Error computing tablet management actions for Root extent", e);
           error = e.getMessage();
         }
+
+        if (VolumeUtil.needsVolumeReplacement(parameters.getVolumeReplacements(), tm)) {
+          actions.add(ManagementAction.NEEDS_VOLUME_REPLACEMENT);
+        }
+
         return new TabletManagement(actions, tm, error);
 
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -170,23 +170,6 @@ public class MetadataTableUtil {
 
   }
 
-  public static void updateTabletVolumes(KeyExtent extent, List<LogEntry> logsToRemove,
-      List<LogEntry> logsToAdd, List<StoredTabletFile> filesToRemove,
-      SortedMap<ReferencedTabletFile,DataFileValue> filesToAdd, ServiceLock zooLock,
-      ServerContext context) {
-
-    TabletMutator tabletMutator = context.getAmple().mutateTablet(extent);
-    logsToRemove.forEach(tabletMutator::deleteWal);
-    logsToAdd.forEach(tabletMutator::putWal);
-
-    filesToRemove.forEach(tabletMutator::deleteFile);
-    filesToAdd.forEach(tabletMutator::putFile);
-
-    tabletMutator.putZooLock(context.getZooKeeperRoot(), zooLock);
-
-    tabletMutator.mutate();
-  }
-
   public static void rollBackSplit(Text metadataEntry, Text oldPrevEndRow, ServerContext context,
       ServiceLock zooLock) {
     KeyExtent ke = KeyExtent.fromMetaRow(metadataEntry, oldPrevEndRow);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -404,8 +404,8 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       final Set<ManagementAction> actions = mti.getActions();
       if (tm.isFutureAndCurrentLocationSet()) {
-        throw new BadLocationStateException(tm.getExtent()
-            + " is both assigned and hosted, which should never happen: " + this,
+        throw new BadLocationStateException(
+            tm.getExtent() + " is both assigned and hosted, which should never happen: " + this,
             tm.getExtent().toMetaRow());
       }
 
@@ -435,15 +435,15 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       if (actions.contains(ManagementAction.NEEDS_VOLUME_REPLACEMENT)) {
         tableMgmtStats.totalVolumeReplacements++;
-        var volRep = VolumeUtil.computeVolumeReplacements(tableMgmtParams.getVolumeReplacements(),
-            tm);
+        var volRep =
+            VolumeUtil.computeVolumeReplacements(tableMgmtParams.getVolumeReplacements(), tm);
 
         if (volRep.logsToRemove.size() + volRep.filesToRemove.size() > 0) {
           if (tm.getLocation() != null) {
             // since the totalVolumeReplacements counter was incremented, should try this again
             // later after its unassigned
-            LOG.debug("Volume replacement needed for {} but it has a location {}.",
-                tm.getExtent(), tm.getLocation());
+            LOG.debug("Volume replacement needed for {} but it has a location {}.", tm.getExtent(),
+                tm.getLocation());
           } else if (tm.getOperationId() != null) {
             LOG.debug("Volume replacement needed for {} but it has an active operation {}.",
                 tm.getExtent(), tm.getOperationId());
@@ -453,8 +453,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
             tLists.volumeReplacements.add(volRep);
           }
         } else {
-          LOG.debug("Volume replacement evaluation for {} returned no changes.",
-              tm.getExtent());
+          LOG.debug("Volume replacement evaluation for {} returned no changes.", tm.getExtent());
         }
       }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
@@ -60,18 +62,14 @@ import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.core.util.threads.Threads.AccumuloDaemonThread;
@@ -95,7 +93,6 @@ import org.apache.accumulo.server.manager.state.TabletManagementIterator;
 import org.apache.accumulo.server.manager.state.TabletManagementParameters;
 import org.apache.accumulo.server.manager.state.TabletStateStore;
 import org.apache.accumulo.server.manager.state.UnassignedTablet;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
@@ -178,6 +175,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     // read only list of tablet servers that are not shutting down
     private final SortedMap<TServerInstance,TabletServerStatus> destinations;
     private final Map<String,Set<TServerInstance>> currentTServerGrouping;
+    private final List<VolumeUtil.VolumeReplacements> volumeReplacements = new ArrayList<>();
 
     public TabletLists(SortedMap<TServerInstance,TabletServerStatus> curTServers,
         Map<String,Set<TServerInstance>> grouping, Set<TServerInstance> serversToShutdown) {
@@ -212,6 +210,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       assignedToDeadServers.clear();
       suspendedToGoneServers.clear();
       unassigned.clear();
+      volumeReplacements.clear();
     }
   }
 
@@ -384,14 +383,13 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     Set<TServerInstance> filteredServersToShutdown =
         new HashSet<>(tableMgmtParams.getServersToShutdown());
 
-    long volReplacements = 0;
     while (iter.hasNext()) {
       final TabletManagement mti = iter.next();
       if (mti == null) {
         throw new IllegalStateException("State store returned a null ManagerTabletInfo object");
       }
 
-      TabletMetadata tabletMeta = mti.getTabletMetadata();
+      final TabletMetadata tm = mti.getTabletMetadata();
 
       final String mtiError = mti.getErrorMessage();
       if (mtiError != null) {
@@ -399,19 +397,19 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         // when trying to process this extent.
         LOG.warn(
             "Error on TabletServer trying to get Tablet management information for extent: {}. Error message: {}",
-            tabletMeta.getExtent(), mtiError);
+            tm.getExtent(), mtiError);
         this.metrics.incrementTabletGroupWatcherError(this.store.getLevel());
         continue;
       }
 
       final Set<ManagementAction> actions = mti.getActions();
-      if (tabletMeta.isFutureAndCurrentLocationSet()) {
-        throw new BadLocationStateException(tabletMeta.getExtent()
+      if (tm.isFutureAndCurrentLocationSet()) {
+        throw new BadLocationStateException(tm.getExtent()
             + " is both assigned and hosted, which should never happen: " + this,
-            tabletMeta.getExtent().toMetaRow());
+            tm.getExtent().toMetaRow());
       }
 
-      final TableId tableId = tabletMeta.getTableId();
+      final TableId tableId = tm.getTableId();
       // ignore entries for tables that do not exist in zookeeper
       if (manager.getTableManager().getTableState(tableId) == null) {
         continue;
@@ -419,7 +417,8 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       // Don't overwhelm the tablet servers with work
       if (tLists.unassigned.size() + unloaded
-          > Manager.MAX_TSERVER_WORK_CHUNK * currentTServers.size()) {
+          > Manager.MAX_TSERVER_WORK_CHUNK * currentTServers.size()
+          || tLists.volumeReplacements.size() > 1000) {
         flushChanges(tLists);
         tLists.reset();
         unloaded = 0;
@@ -427,44 +426,39 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       final TableConfiguration tableConf = manager.getContext().getTableConfiguration(tableId);
 
-      final TabletState state = TabletState.compute(tabletMeta, currentTServers.keySet());
+      final TabletState state = TabletState.compute(tm, currentTServers.keySet());
       // This is final because nothing in this method should change the goal. All computation of the
       // goal should be done in TabletGoalState.compute() so that all parts of the Accumulo code
       // will compute a consistent goal.
-      TabletGoalState goal =
-          TabletGoalState.compute(tabletMeta, state, manager.tabletBalancer, tableMgmtParams);
+      final TabletGoalState goal =
+          TabletGoalState.compute(tm, state, manager.tabletBalancer, tableMgmtParams);
 
       if (actions.contains(ManagementAction.NEEDS_VOLUME_REPLACEMENT)) {
-        volReplacements++;
-        LOG.debug("{} may need volume replacement", tabletMeta.getExtent());
-        final List<LogEntry> logsToRemove = new ArrayList<>();
-        final List<LogEntry> logsToAdd = new ArrayList<>();
-        final List<StoredTabletFile> filesToRemove = new ArrayList<>();
-        final SortedMap<ReferencedTabletFile,DataFileValue> filesToAdd = new TreeMap<>();
+        tableMgmtStats.totalVolumeReplacements++;
+        var volRep = VolumeUtil.computeVolumeReplacements(tableMgmtParams.getVolumeReplacements(),
+            tm);
 
-        VolumeUtil.volumeReplacementEvaluation(tableMgmtParams.getVolumeReplacements(), tabletMeta,
-            logsToRemove, logsToAdd, filesToRemove, filesToAdd);
-
-        if (logsToRemove.size() + filesToRemove.size() > 0) {
-          // ELASTICITY_TODO: Is using the Manager lock here correct?
-          LOG.debug("Volume replacement needed for {}.", tabletMeta.getExtent());
-          MetadataTableUtil.updateTabletVolumes(tabletMeta.getExtent(), logsToRemove, logsToAdd,
-              filesToRemove, filesToAdd, manager.getManagerLock(), manager.getContext());
-          // We need to refresh the TabletMetadata
-          tabletMeta = manager.getContext().getAmple().readTablet(tabletMeta.getExtent(),
-              TabletManagement.CONFIGURED_COLUMNS.toArray(ColumnType.values()));
-          goal = TabletGoalState.UNASSIGNED;
-          actions.add(ManagementAction.NEEDS_LOCATION_UPDATE);
-          LOG.debug("Volume replacement completed for {}. Requesting un-assignment.",
-              tabletMeta.getExtent());
+        if (volRep.logsToRemove.size() + volRep.filesToRemove.size() > 0) {
+          if (tm.getLocation() != null) {
+            // since the totalVolumeReplacements counter was incremented, should try this again
+            // later after its unassigned
+            LOG.debug("Volume replacement needed for {} but it has a location {}.",
+                tm.getExtent(), tm.getLocation());
+          } else if (tm.getOperationId() != null) {
+            LOG.debug("Volume replacement needed for {} but it has an active operation {}.",
+                tm.getExtent(), tm.getOperationId());
+          } else {
+            LOG.debug("Volume replacement needed for {}.", tm.getExtent());
+            // buffer replacements so that multiple mutations can be done at once
+            tLists.volumeReplacements.add(volRep);
+          }
         } else {
           LOG.debug("Volume replacement evaluation for {} returned no changes.",
-              tabletMeta.getExtent());
+              tm.getExtent());
         }
       }
-      final TabletMetadata tm = tabletMeta;
 
-      final Location location = tabletMeta.getLocation();
+      final Location location = tm.getLocation();
       Location current = null;
       Location future = null;
       if (tm.hasCurrent()) {
@@ -585,7 +579,6 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         tableMgmtStats.counts[state.ordinal()]++;
       }
     }
-    tableMgmtStats.totalVolumeReplacements = volReplacements;
 
     flushChanges(tLists);
 
@@ -935,6 +928,37 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       }
       manager.assignedTablet(a.tablet);
     }
+
+    replaceVolumes(tLists.volumeReplacements);
+  }
+
+  private void replaceVolumes(List<VolumeUtil.VolumeReplacements> volumeReplacementsList) {
+    try (var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
+      for (VolumeUtil.VolumeReplacements vr : volumeReplacementsList) {
+        // ELASTICITY_TODO can require same on WALS once that is implemented, see #3948
+        var tabletMutator = tabletsMutator.mutateTablet(vr.tabletMeta.getExtent())
+            .requireAbsentOperation().requireAbsentLocation().requireSame(vr.tabletMeta, FILES);
+        vr.logsToRemove.forEach(tabletMutator::deleteWal);
+        vr.logsToAdd.forEach(tabletMutator::putWal);
+
+        vr.filesToRemove.forEach(tabletMutator::deleteFile);
+        vr.filesToAdd.forEach(tabletMutator::putFile);
+
+        tabletMutator.putZooLock(manager.getContext().getZooKeeperRoot(), manager.getManagerLock());
+
+        tabletMutator.submit(
+            tm -> tm.getLogs().containsAll(vr.logsToAdd) && tm.getFiles().containsAll(vr.filesToAdd
+                .keySet().stream().map(ReferencedTabletFile::insert).collect(Collectors.toSet())));
+      }
+
+      tabletsMutator.process().forEach((extent, result) -> {
+        if (result.getStatus() == Ample.ConditionalResult.Status.REJECTED) {
+          // log that failure happened, should try again later
+          LOG.debug("Failed to update volumes for tablet {}", extent);
+        }
+      });
+    }
+
   }
 
   private static void markDeadServerLogsAsClosed(WalStateManager mgr,
@@ -945,5 +969,4 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       }
     }
   }
-
 }

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -87,12 +87,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException.NoNodeException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@Disabled // ELASTICITY_TODO
 public class VolumeIT extends ConfigurableMacBase {
 
   private File volDirBase;


### PR DESCRIPTION
Implemented volume replacement for root tablet.

Made tablets have a goal state of unassigned when volume replacement is needed.

Used a conditional writer to make volume replacement updates.

Buffered volume replacement updates so that many updates could be made using a shared conditional writer.

Fixed an issue in mini accumulo cluster that prevented VolumeIT from running.  Got VolumeIT running.

Optimized check for needs volume replacement to avoid creating collections.