### PR TITLE
Update to use two encoders for key/value set comparison

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -54,6 +54,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMutatorBase;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
+import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.metadata.iterators.LocationExistsIterator;
 import org.apache.accumulo.server.metadata.iterators.PresentIterator;
@@ -173,9 +174,11 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
       }
         break;
       case FILES: {
-        Condition c = SetEqualityIterator.createCondition(tabletMetadata.getFilesMap().entrySet(),
-            entry -> entry.getKey().getMetadata().getBytes(UTF_8),
-            entry -> entry.getValue().encode(), DataFileColumnFamily.NAME);
+        Condition c =
+            SetEqualityIterator.createConditionWithVal(tabletMetadata.getFilesMap().entrySet(),
+                entry -> new Pair<>(entry.getKey().getMetadata().getBytes(UTF_8),
+                    entry.getValue().encode()),
+                DataFileColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -168,16 +168,14 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
       case LOGS: {
         Condition c = SetEqualityIterator.createCondition(new HashSet<>(tabletMetadata.getLogs()),
             logEntry -> logEntry.getColumnQualifier().toString().getBytes(UTF_8),
-            LogColumnFamily.NAME, false);
+            LogColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;
       case FILES: {
         Condition c = SetEqualityIterator.createCondition(tabletMetadata.getFilesMap().entrySet(),
-            (entry) -> {
-              return (entry.getKey().getMetadata() + SetEqualityIterator.VALUE_SEPARATOR
-                  + entry.getValue().encodeAsString()).getBytes(UTF_8);
-            }, DataFileColumnFamily.NAME, true);
+            entry -> entry.getKey().getMetadata().getBytes(UTF_8),
+            entry -> entry.getValue().encode(), DataFileColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;
@@ -194,9 +192,9 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
       }
         break;
       case ECOMP: {
-        Condition c = SetEqualityIterator.createCondition(
-            tabletMetadata.getExternalCompactions().keySet(),
-            ecid -> ecid.canonical().getBytes(UTF_8), ExternalCompactionColumnFamily.NAME, false);
+        Condition c =
+            SetEqualityIterator.createCondition(tabletMetadata.getExternalCompactions().keySet(),
+                ecid -> ecid.canonical().getBytes(UTF_8), ExternalCompactionColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;
@@ -209,13 +207,13 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
         break;
       case LOADED: {
         Condition c = SetEqualityIterator.createCondition(tabletMetadata.getLoaded().keySet(),
-            stf -> stf.getMetadata().getBytes(UTF_8), BulkFileColumnFamily.NAME, false);
+            stf -> stf.getMetadata().getBytes(UTF_8), BulkFileColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;
       case COMPACTED: {
         Condition c = SetEqualityIterator.createCondition(tabletMetadata.getCompacted(),
-            fTid -> fTid.canonical().getBytes(UTF_8), CompactedColumnFamily.NAME, false);
+            fTid -> fTid.canonical().getBytes(UTF_8), CompactedColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;
@@ -236,9 +234,9 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
       }
         break;
       case USER_COMPACTION_REQUESTED: {
-        Condition c = SetEqualityIterator.createCondition(
-            tabletMetadata.getUserCompactionsRequested(), fTid -> fTid.canonical().getBytes(UTF_8),
-            UserCompactionRequestedColumnFamily.NAME, false);
+        Condition c =
+            SetEqualityIterator.createCondition(tabletMetadata.getUserCompactionsRequested(),
+                fTid -> fTid.canonical().getBytes(UTF_8), UserCompactionRequestedColumnFamily.NAME);
         mutation.addCondition(c);
       }
         break;

--- a/server/base/src/test/java/org/apache/accumulo/server/SetEqualityIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/SetEqualityIteratorTest.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.metadata.iterators.SetEqualityIterator;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -154,8 +155,9 @@ public class SetEqualityIteratorTest {
     // Asserting the result
     assertEquals(new Key(tabletRow, family), setEqualityIteratorOneFile.getTopKey());
     // The iterator should produce a value that is equal to the expected value on the condition
-    var condition = SetEqualityIterator.createCondition(tmOneFile.getFilesMap().entrySet(),
-        entry -> entry.getKey().getMetadata().getBytes(UTF_8), entry -> entry.getValue().encode(),
+    var condition = SetEqualityIterator.createConditionWithVal(tmOneFile.getFilesMap().entrySet(),
+        entry -> new Pair<>(entry.getKey().getMetadata().getBytes(UTF_8),
+            entry.getValue().encode()),
         family);
     assertArrayEquals(condition.getValue().toArray(),
         setEqualityIteratorOneFile.getTopValue().get());
@@ -175,9 +177,11 @@ public class SetEqualityIteratorTest {
     // Asserting the result
     assertEquals(new Key(tabletRow, family), setEqualityIterator.getTopKey());
     // The iterator should produce a value that is equal to the expected value on the condition
-    var condition = SetEqualityIterator.createCondition(tmMultipleFiles.getFilesMap().entrySet(),
-        entry -> entry.getKey().getMetadata().getBytes(UTF_8), entry -> entry.getValue().encode(),
-        family);
+    var condition =
+        SetEqualityIterator.createConditionWithVal(tmMultipleFiles.getFilesMap().entrySet(),
+            entry -> new Pair<>(entry.getKey().getMetadata().getBytes(UTF_8),
+                entry.getValue().encode()),
+            family);
     assertArrayEquals(condition.getValue().toArray(), setEqualityIterator.getTopValue().get());
 
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/SetEqualityIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/SetEqualityIteratorTest.java
@@ -135,7 +135,7 @@ public class SetEqualityIteratorTest {
     // The iterator should produce a value that is equal to the expected value on the condition
     var condition = SetEqualityIterator.createCondition(Collections.emptySet(),
         storedTabletFile -> ((StoredTabletFile) storedTabletFile).getMetadata().getBytes(UTF_8),
-        family, false);
+        family);
     assertArrayEquals(condition.getValue().toArray(),
         setEqualityIteratorNoFiles.getTopValue().get());
   }
@@ -154,11 +154,9 @@ public class SetEqualityIteratorTest {
     // Asserting the result
     assertEquals(new Key(tabletRow, family), setEqualityIteratorOneFile.getTopKey());
     // The iterator should produce a value that is equal to the expected value on the condition
-    var condition =
-        SetEqualityIterator.createCondition(tmOneFile.getFilesMap().entrySet(), entry -> {
-          return (entry.getKey().getMetadata() + SetEqualityIterator.VALUE_SEPARATOR
-              + entry.getValue().encodeAsString()).getBytes(UTF_8);
-        }, family, true);
+    var condition = SetEqualityIterator.createCondition(tmOneFile.getFilesMap().entrySet(),
+        entry -> entry.getKey().getMetadata().getBytes(UTF_8), entry -> entry.getValue().encode(),
+        family);
     assertArrayEquals(condition.getValue().toArray(),
         setEqualityIteratorOneFile.getTopValue().get());
   }
@@ -177,11 +175,9 @@ public class SetEqualityIteratorTest {
     // Asserting the result
     assertEquals(new Key(tabletRow, family), setEqualityIterator.getTopKey());
     // The iterator should produce a value that is equal to the expected value on the condition
-    var condition =
-        SetEqualityIterator.createCondition(tmMultipleFiles.getFilesMap().entrySet(), entry -> {
-          return (entry.getKey().getMetadata() + SetEqualityIterator.VALUE_SEPARATOR
-              + entry.getValue().encodeAsString()).getBytes(UTF_8);
-        }, family, true);
+    var condition = SetEqualityIterator.createCondition(tmMultipleFiles.getFilesMap().entrySet(),
+        entry -> entry.getKey().getMetadata().getBytes(UTF_8), entry -> entry.getValue().encode(),
+        family);
     assertArrayEquals(condition.getValue().toArray(), setEqualityIterator.getTopValue().get());
 
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
@@ -319,9 +319,8 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
           .putFile(stf4, new DataFileValue(0, 0)).deleteFile(stf1).deleteFile(stf2).deleteFile(stf3)
           .submit(tm -> false);
       results = ctmi.process();
-      // First attempt should fail because the dfvs were replaced in the test so the values of the
-      // files
-      // will not match
+      // First attempt should fail because the dfvs were replaced in the test
+      // so the values of the files will not match
       assertEquals(Status.REJECTED, results.get(e1).getStatus());
 
       // Try again with the correct comapcted datafiles

--- a/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
@@ -319,6 +319,20 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
           .putFile(stf4, new DataFileValue(0, 0)).deleteFile(stf1).deleteFile(stf2).deleteFile(stf3)
           .submit(tm -> false);
       results = ctmi.process();
+      // First attempt should fail because the dfvs were replaced in the test so the values of the
+      // files
+      // will not match
+      assertEquals(Status.REJECTED, results.get(e1).getStatus());
+
+      // Try again with the correct comapcted datafiles
+      var compactedDv = new DataFileValue(0, 0);
+      ctmi = new ConditionalTabletsMutatorImpl(context);
+      tm5 = TabletMetadata.builder(e1).putFile(stf1, compactedDv).putFile(stf2, compactedDv)
+          .putFile(stf3, compactedDv).build();
+      ctmi.mutateTablet(e1).requireAbsentOperation().requireSame(tm5, FILES)
+          .putFile(stf4, new DataFileValue(0, 0)).deleteFile(stf1).deleteFile(stf2).deleteFile(stf3)
+          .submit(tm -> false);
+      results = ctmi.process();
       assertEquals(Status.ACCEPTED, results.get(e1).getStatus());
 
       assertEquals(Set.of(stf4), context.getAmple().readTablet(e1).getFiles());
@@ -332,7 +346,7 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
       FateId fateId = FateId.from(type, UUID.randomUUID());
       ctmi.mutateTablet(e1).requireAbsentOperation().requireSame(tm6, LOADED)
           .putFile(stf5, new DataFileValue(0, 0)).putBulkFile(stf5.getTabletFile(), fateId)
-          .putFile(stf5, new DataFileValue(0, 0)).submit(tm -> false);
+          .submit(tm -> false);
       results = ctmi.process();
       assertEquals(Status.ACCEPTED, results.get(e1).getStatus());
 
@@ -342,7 +356,8 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
       var stf6 = StoredTabletFile
           .of(new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/A0000075.rf"));
       ctmi = new ConditionalTabletsMutatorImpl(context);
-      var tm7 = TabletMetadata.builder(e1).putFile(stf4, dfv).putFile(stf5, dfv).build();
+      var tm7 =
+          TabletMetadata.builder(e1).putFile(stf4, compactedDv).putFile(stf5, compactedDv).build();
       ctmi.mutateTablet(e1).requireAbsentOperation().requireSame(tm7, FILES)
           .putFile(stf6, new DataFileValue(0, 0)).deleteFile(stf4).deleteFile(stf5)
           .submit(tm -> false);


### PR DESCRIPTION
This change allows the logic for serializing and comparing both a key/value of items in a set away from building the conditional mutation to make the comparison easier and less error prone.

I also fixed the issue with AmpleConditionalWriteIT and improved it. It was failing because the change worked, the values in the test were not equal due to simulating a compaction and changing the DataFileValues in the test so the mutation was rejected.