### PR TITLE
Improve the upgrade tracking and validation

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/PreUpgradeValidation.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/PreUpgradeValidation.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.core.zookeeper.ZooSession.ZKUtil;
-import org.apache.accumulo.manager.EventCoordinator;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
@@ -48,10 +47,11 @@ public class PreUpgradeValidation {
 
   private final static Logger log = LoggerFactory.getLogger(PreUpgradeValidation.class);
 
-  public void validate(final ServerContext context, final EventCoordinator eventCoordinator) {
-    int cv = AccumuloDataVersion.getCurrentVersion(context);
-    if (cv == AccumuloDataVersion.get()) {
-      log.debug("already at current data version: {}, skipping validation", cv);
+  public void validate(final ServerContext context) {
+    int storedVersion = AccumuloDataVersion.getCurrentVersion(context);
+    int currentVersion = AccumuloDataVersion.get();
+    if (storedVersion == currentVersion) {
+      log.debug("already at current data version: {}, skipping validation", currentVersion);
       return;
     }
     validateACLs(context);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
+/**
+ * Track upgrade progress for each component. The version stored is the most recent version for
+ * which an upgrade has been completed.
+ */
+public class UpgradeProgress {
+
+  int zooKeeperVersion;
+  int rootVersion;
+  int metadataVersion;
+  int upgradeTargetVersion;
+
+  public UpgradeProgress() {}
+
+  public UpgradeProgress(int currentVersion, int targetVersion) {
+    zooKeeperVersion = currentVersion;
+    rootVersion = currentVersion;
+    metadataVersion = currentVersion;
+    upgradeTargetVersion = targetVersion;
+  }
+
+  public int getZooKeeperVersion() {
+    return zooKeeperVersion;
+  }
+
+  public int getRootVersion() {
+    return rootVersion;
+  }
+
+  public int getMetadataVersion() {
+    return metadataVersion;
+  }
+
+  public int getUpgradeTargetVersion() {
+    return upgradeTargetVersion;
+  }
+
+  public byte[] toJsonBytes() {
+    return GSON.get().toJson(this).getBytes(UTF_8);
+  }
+
+  public static UpgradeProgress fromJsonBytes(byte[] jsonData) {
+    return GSON.get().fromJson(new String(jsonData, UTF_8), UpgradeProgress.class);
+  }
+
+}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UpgradeProgressTest {
+
+  @Test
+  void testInitialize() {
+    var progress = new UpgradeProgress(42, 1042);
+    assertEquals(42, progress.getZooKeeperVersion());
+    assertEquals(42, progress.getRootVersion());
+    assertEquals(42, progress.getMetadataVersion());
+
+    var progress2 = new UpgradeProgress();
+    assertEquals(0, progress2.getZooKeeperVersion());
+    assertEquals(0, progress2.getRootVersion());
+    assertEquals(0, progress2.getMetadataVersion());
+  }
+
+  @Test
+  void testToFromJson() {
+    var progress = new UpgradeProgress();
+    progress.zooKeeperVersion = 5001;
+    progress.rootVersion = 5002;
+    progress.metadataVersion = 5003;
+    progress.upgradeTargetVersion = 5004;
+
+    // serialize and deserialize
+    byte[] jsonBytes = progress.toJsonBytes();
+    var progress2 = UpgradeProgress.fromJsonBytes(jsonBytes);
+    assertEquals(5001, progress2.getZooKeeperVersion());
+    assertEquals(5002, progress2.getRootVersion());
+    assertEquals(5003, progress2.getMetadataVersion());
+    assertEquals(5004, progress2.getUpgradeTargetVersion());
+
+    // show original is unchanged
+    assertEquals(5001, progress.getZooKeeperVersion());
+    assertEquals(5002, progress.getRootVersion());
+    assertEquals(5003, progress.getMetadataVersion());
+    assertEquals(5004, progress.getUpgradeTargetVersion());
+
+    // test deserialization with a test json string, so we know the deserialization/serialization is
+    // actually using json, and not some other reversible format
+    var json =
+        "{\"zooKeeperVersion\":7001,\"rootVersion\":7002,\"metadataVersion\":7003,\"upgradeTargetVersion\":7004}";
+    var progress3 = UpgradeProgress.fromJsonBytes(json.getBytes(UTF_8));
+    assertEquals(7001, progress3.getZooKeeperVersion());
+    assertEquals(7002, progress3.getRootVersion());
+    assertEquals(7003, progress3.getMetadataVersion());
+    assertEquals(7004, progress3.getUpgradeTargetVersion());
+  }
+
+}


### PR DESCRIPTION
* Pass along the ServerContext into the PreUpgradeValidation and UpgradeCoordinator classes, so it doesn't have to be passed later
* Drop the unused EventCoordinator from the PreUpgradeValidation
* Put the PreUpgradeValidation and the UpgradeProgressTracker inside the UpgradeCoordinator (since they are related responsibilities)
* Initialize the UpgradeProgressTracker in the UpgradeCoordinator after the Manager gains its lock to avoid race conditions between different managers trying to initialize the upgrade progress node separately (this was probably already avoided, but these changes make it easier to reason about, since the manager lock is required first, and only one can have it)
* Separate out the UpgradeProgress class and its serialization fromt he UpgradeProgressTracker class, and give it its own unit test
* Avoid propagating KeeperException/InterruptedException when not needed
* Use explicit startOrContinueUpgrade methods to avoid relying on initializing the upgrade progress node as a side effect of reading it
* Move the znodeVersion tracking for ensuring sequential writes to ZK upgrade progress into the tracker, rather than in the UpgradeProgress class
* Fix EasyMock usage in AccumuloTest unit test for upgrades observed while adding the context to the UpgradeCoordinator constructor