### PR TITLE
move ColumnJsGen run into prepare-package build step

### DIFF
--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -221,26 +221,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>metrics-javascript</id>
-              <goals>
-                <goal>java</goal>
-              </goals>
-              <phase>prepare-package</phase>
-              <configuration>
-                <mainClass>org.apache.accumulo.monitor.next.views.ColumnJsGen</mainClass>
-                <classpathScope>compile</classpathScope>
-                <arguments>
-                  <argument>${project.build.directory}/classes/org/apache/accumulo/monitor/resources/js/columns.js</argument>
-                </arguments>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <configuration>
@@ -266,6 +246,26 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>metrics-javascript</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <mainClass>org.apache.accumulo.monitor.next.views.ColumnJsGen</mainClass>
+              <classpathScope>compile</classpathScope>
+              <arguments>
+                <argument>${project.build.directory}/classes/org/apache/accumulo/monitor/resources/js/columns.js</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
this step was not running during the build (for me at least). It now runs during the `prepare-package` build step