### PR TITLE
Fix Compaction Overview tables

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -504,6 +504,15 @@ public class SystemInformation {
 
   private ServersView createCompactionQueueSummary(final Set<ServerId> managers) {
 
+    final Column COMPACTION_QUEUE_COL =
+        new Column(ServersView.RG_COL_KEY, "Compaction Queue", "Compaction Queue", "");
+
+    List<Column> cols = ServersView.columnsFor(ServersView.ServerTable.COORDINATOR_QUEUES);
+    // Remove the column mapping for the resource group and replace it so that
+    // the column header reads "Compaction Queue" instead of "Resource Group"
+    int index = cols.indexOf(ServersView.RG_COLUMN);
+    cols.set(index, COMPACTION_QUEUE_COL);
+
     // Construct a Map of MetricResponses by Queue. This method will take
     // the provided MetricResponse and construct new ones that contain
     // only the metrics with the "queue.id" tag in addition to the common
@@ -537,18 +546,9 @@ public class SystemInformation {
 
     if (!qm.isEmpty()) {
       // Create a ServersView object from the MetricResponse for each queue
-      final Column COMPACTION_QUEUE_COL =
-          new Column(ServersView.RG_COL_KEY, "Compaction Queue", "Compaction Queue", "");
-
-      List<Column> cols = ServersView.columnsFor(ServersView.ServerTable.COORDINATOR_QUEUES);
-      // Remove the column mapping for the resource group and replace it so that
-      // the column header reads "Compaction Queue" instead of "Resource Group"
-      int index = cols.indexOf(ServersView.RG_COLUMN);
-      cols.set(index, COMPACTION_QUEUE_COL);
-
       return new ServersView(qm.keySet(), 0, qm, timestamp.get(), cols);
     }
-    return null;
+    return new ServersView(Set.of(), 0, Map.of(), timestamp.get(), cols);
   }
 
   public void processResponse(final ServerId server, final MetricResponse response) {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
@@ -33,6 +33,13 @@ const runningQueueHtmlTable = '#queue_running';
 var tableRunning;
 var queueRunning;
 
+function getStoredArray(storageKey) {
+  if (!sessionStorage[storageKey]) {
+    return [];
+  }
+  return JSON.parse(sessionStorage[storageKey]);
+}
+
 function refresh() {
   $.when(getRunningCompactionsByTable(), getRunningCompactionsByGroup(), getCoordinatorQueueView(), getManagersCompactionView()).then(function () {
     refreshTable(coordinatorHtmlTable, MANAGER_COMPACTION_SERVER_PROCESS_VIEW);
@@ -81,7 +88,7 @@ $(function () {
   tableRunning = $(runningTableHtmlTable).DataTable({
     "ajax": function (data, callback) {
       callback({
-        data: getRunningCompactionsByTable()
+        data: getStoredArray(RUNNING_COMPACTIONS_BY_TABLE)
       });
     },
     "stateSave": true,
@@ -102,7 +109,7 @@ $(function () {
   queueRunning = $(runningQueueHtmlTable).DataTable({
     "ajax": function (data, callback) {
       callback({
-        data: getRunningCompactionsByGroup()
+        data: getStoredArray(RUNNING_COMPACTIONS_BY_GROUP)
       });
     },
     "stateSave": true,


### PR DESCRIPTION
This fixes two issues I saw with the tables:
1. The DataTables were trying to use the getRunningCompactionsBy...() methods directly however those methods return a request object as opposed to an actual table row data object. To fix this, i made a small helper method that reads the arrays from the session storage that were already populated.
2. When no queue metrics existed, i was seeing 404 errors in the console. This was because null was being returned when no metrics were found. Now, an empty ServersView object is returned so the table renders and doesn't throw an error.