### PR TITLE
Fix load order bug and refactor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
@@ -26,13 +26,6 @@ const runningQueueHtmlTable = '#queue_running';
 var tableRunning;
 var queueRunning;
 
-function getStoredArray(storageKey) {
-  if (!sessionStorage[storageKey]) {
-    return [];
-  }
-  return JSON.parse(sessionStorage[storageKey]);
-}
-
 function refresh() {
   $.when(getRunningCompactionsByTable(), getRunningCompactionsByGroup(), getCoordinatorQueueView(), getManagersCompactionView()).then(function () {
     refreshTable(coordinatorHtmlTable, MANAGER_COMPACTION_SERVER_PROCESS_VIEW);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -374,6 +374,20 @@ function getJSONForTable(call, sessionDataVar) {
   });
 }
 
+function getStoredJson(storageKey, defaultValue) {
+  var storedValue = sessionStorage.getItem(storageKey);
+  if (!storedValue) {
+    return defaultValue;
+  }
+
+  return JSON.parse(storedValue);
+}
+
+function getStoredArray(storageKey) {
+  var storedValue = getStoredJson(storageKey, []);
+  return Array.isArray(storedValue) ? storedValue : [];
+}
+
 /**
  * Performs POST call and builds console logging message if successful
  * @param {string} call REST url called

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/messages.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/messages.js
@@ -82,10 +82,7 @@ function updateMessagePriorities() {
  */
 function updateMessageCategories() {
 
-  var categories = JSON.parse(sessionStorage[MESSAGE_CATEGORIES]);
-  if (!Array.isArray(categories)) {
-    categories = [];
-  }
+  var categories = getStoredArray(MESSAGE_CATEGORIES);
 
   var categoryList = $(messageCategoryList);
   $.each(categories, function (index, cat) {
@@ -152,31 +149,34 @@ function fetchTableData() {
     info = true;
   }
 
-  var categories = JSON.parse(sessionStorage[MESSAGE_CATEGORIES]);
-  if (!Array.isArray(categories)) {
-    categories = [];
+  var categories = getStoredArray(MESSAGE_CATEGORIES);
+  if (categories.length === 0) {
+    sessionStorage.setItem(MESSAGES, JSON.stringify([]));
+    return $.Deferred().resolve().promise();
   }
-  if (categories.length !== 0) {
-    var cats = [];
-    $.each(categories, function (index, cat) {
-      var savedValue = localStorage.getItem("msg-cat-switch-" + cat + "-state");
-      if (savedValue === null || savedValue === 'true') {
-        cats.push(cat);
-      }
-    });
-    getMessages(high, info, cats);
-  }
+
+  var cats = [];
+  $.each(categories, function (index, cat) {
+    var savedValue = localStorage.getItem("msg-cat-switch-" + cat + "-state");
+    if (savedValue === null || savedValue === 'true') {
+      cats.push(cat);
+    }
+  });
+  return getMessages(high, info, cats);
 }
 
 function getTableData() {
-  if (!sessionStorage[MESSAGES]) {
-    return [];
-  }
-  return JSON.parse(sessionStorage[MESSAGES]);
+  return getStoredArray(MESSAGES);
+}
+
+function loadMessagesPageData() {
+  return getMessageCategories().then(function () {
+    return fetchTableData();
+  });
 }
 
 function refresh() {
-  $.when(getMessageCategories(), fetchTableData()).then(function () {
+  return loadMessagesPageData().then(function () {
     updateMessagePriorities();
     updateMessageCategories();
     if (dataTableRef) {
@@ -213,7 +213,7 @@ function createDataTable() {
 }
 
 $(function () {
-  $.when(getMessageCategories(), fetchTableData()).then(function () {
+  loadMessagesPageData().then(function () {
     updateMessagePriorities();
     updateMessageCategories();
     createDataTable();

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
@@ -67,10 +67,7 @@ var dataTableRefs = new Map();
  * This function returns the entire response from session storage
  */
 function getStoredView(storageKey) {
-  if (!sessionStorage[storageKey]) {
-    return {};
-  }
-  return JSON.parse(sessionStorage[storageKey]);
+  return getStoredJson(storageKey, {});
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/messages.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/messages.ftl
@@ -20,10 +20,10 @@
 -->
     <br />
     <div class="col-xs-12" id="messages">
-      <h5>Message Priority Settings <small>(critical messages are always shown)</small></h5>
+      <h5>Message Priority Filters <small>(critical messages are always shown)</small></h5>
       <div id="message-priority-list"></div>
       <br />
-      <h5>Message Category Settings</h5>
+      <h5>Message Category Filters</h5>
       <div id="message-category-list"></div>
       <br />
       <h5>Messages</h5>


### PR DESCRIPTION
Main thing fixed:

On page load, I was seeing a `Uncaught SyntaxError: "undefined" is not valid JSON` exception in the console. I think this would only happen on page load but I was able to track it down to a race condition with `getMessageCategories()` and `fetchTableData()` running in parallel but `fetchTableData()` looks for the `sessionStorage[MESSAGE_CATEGORIES]` which hadn't been set yet. To fix this I changed to `getMessageCategories().then(() => fetchTableData())` so its set in the right order.

Other small changes:
* in `fetchTableData()` now return `$.Deferred().resolve().promise()` when the category session storage is empty which is the jquery way to say "loading complete, there was just nothing to request"
* added a shared `getStoredArray()` helper to `functions.js`
* Changed the word "Settings" -> "Filters" for the switch toggles

Visually looks the same except the settings -> filters word change
<img width="1841" height="908" alt="image" src="https://github.com/user-attachments/assets/9759b095-db66-4d7f-9fe5-566a9d2d89e1" />
