### PR TITLE
Dark mode fixes

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -176,7 +176,8 @@ function updateDarkThemeSwitch() {
   }
 
   darkThemeSwitchElement.on("change", function () {
-    localStorage.setItem(storageKey, $(this).is(':checked'));
-    location.reload();
+    var enableDarkTheme = $(this).is(':checked');
+    localStorage.setItem(storageKey, enableDarkTheme);
+    document.documentElement.setAttribute('data-bs-theme', enableDarkTheme ? 'dark' : 'light');
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -24,8 +24,7 @@
     <base href="${rootContext}"/>
     <title>${title} - Accumulo ${version}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <!-- external resources configurable by setting monitor.resources.external -->
-    <!-- make sure jquery is included first - other scripts depend on it -->
+    <!-- Set the saved theme before loading CSS to reduce light-mode flash on reload -->
     <script>
       (function() {
         if (localStorage.getItem('dark-theme-enabled') === 'true') {
@@ -33,11 +32,13 @@
         }
       })();
     </script>
+    <!-- external resources configurable by setting monitor.resources.external -->
     <#if externalResources?has_content>
       <#list externalResources as val>
         ${val}
       </#list>
     <#else>
+      <!-- make sure jquery is included first - other scripts depend on it -->
       <script src="resources/external/jquery/jquery-3.7.1.js"></script>
       <script src="resources/external/bootstrap/js/bootstrap.bundle.js"></script>
       <script src="resources/external/datatables/js/jquery.dataTables.js"></script>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -26,6 +26,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <!-- external resources configurable by setting monitor.resources.external -->
     <!-- make sure jquery is included first - other scripts depend on it -->
+    <script>
+      (function() {
+        if (localStorage.getItem('dark-theme-enabled') === 'true') {
+          document.documentElement.setAttribute('data-bs-theme', 'dark');
+        }
+      })();
+    </script>
     <#if externalResources?has_content>
       <#list externalResources as val>
         ${val}


### PR DESCRIPTION
* changes in navbar.js allow for theme switching without reloading the page
* changes in default.ftl get rid of light mode flash on refresh when dark mode is enabled